### PR TITLE
Use block bootstrap for residual autocorrelation

### DIFF
--- a/R/RSTR.R
+++ b/R/RSTR.R
@@ -16,6 +16,24 @@ getLowerUpperRSTR <- function(m, confidence) {
   return(list(lower = lu[, 1:(ncol(lu) / 2), drop = FALSE], upper = lu[, (ncol(lu) / 2 + 1):ncol(lu), drop = FALSE]))
 }
 
+block_bootstrap <- function(residuals, n = length(residuals), block_length = NULL) {
+  if (is.null(block_length)) {
+    block_length <- max(floor(n^(1/3)), 1)
+  }
+  num_blocks <- ceiling(n / block_length)
+
+  start_indices <- sample(seq_len(n), size = num_blocks, replace = TRUE)
+  block_offsets <- rep(seq_len(block_length) - 1, times = num_blocks)
+  expanded_starts <- rep(start_indices, each = block_length)
+  indices <- ((expanded_starts + block_offsets) - 1) %% n + 1
+
+  result <- residuals[indices]
+  if (length(result) > n) {
+    result <- result[1:n]
+  }
+  return(result)
+}
+
 #' @title Robust STR decomposition
 #' @description Robust Seasonal-Trend decomposition of time series data using Regression (robust version of \code{\link{STRmodel}}).
 #' @seealso \code{\link{STRmodel}} \code{\link{STR}}
@@ -74,24 +92,6 @@ getLowerUpperRSTR <- function(m, confidence) {
 #' }
 #' @author Alexander Dokumentov
 #' @export
-
-block_bootstrap <- function(residuals, n = length(residuals), block_length = NULL) {
-  if (is.null(block_length)) {
-    block_length <- max(floor(n^(1/3)), 1)
-  }
-  num_blocks <- ceiling(n / block_length)
-
-  start_indices <- sample(seq_len(n), size = num_blocks, replace = TRUE)
-  block_offsets <- rep(seq_len(block_length) - 1, times = num_blocks)
-  expanded_starts <- rep(start_indices, each = block_length)
-  indices <- ((expanded_starts + block_offsets) - 1) %% n + 1
-
-  result <- residuals[indices]
-  if (length(result) > n) {
-    result <- result[1:n]
-  }
-  return(result)
-}
 
 RSTRmodel <- function(data, predictors = NULL, strDesign = NULL, lambdas = NULL,
                       confidence = NULL, # confidence = c(0.8, 0.95)


### PR DESCRIPTION
This PR replaces `sample(res)` in `RSTRmodel` with a block bootstrap. This helps to preserve the autocorrelation in residuals, since the current random shuffling destroys the time-series correlations. The `block_bootstrap` uses the optimal block length $n^{1/3}$ and maintains the same output format as previously.
